### PR TITLE
qcom-common: doze: Set LOCAL_PRIVATE_PLATFORM_APIS

### DIFF
--- a/doze/Android.mk
+++ b/doze/Android.mk
@@ -7,6 +7,7 @@ LOCAL_SRC_FILES := $(call all-java-files-under, src)
 
 LOCAL_PACKAGE_NAME := SamsungDoze
 LOCAL_CERTIFICATE := platform
+LOCAL_PRIVATE_PLATFORM_APIS := true
 LOCAL_PRIVILEGED_MODULE := true
 
 LOCAL_USE_AAPT2 := true


### PR DESCRIPTION
This change sets LOCAL_SDK_VERSION for all packages where
this is possible without breaking the build, and
LOCAL_PRIVATE_PLATFORM_APIS := true otherwise.

Setting one of these two will be made required soon, and this
is a change in preparation for that. Not setting LOCAL_SDK_VERSION
makes the app implicitly depend on the bootclasspath, which is
often not required. This change effectively makes depending on
private apis opt-in rather than opt-out.

Bug: 73535841
Change-Id: Iabb0556dc1c80c7fc7f6c76d61d5e441b03cdce0